### PR TITLE
Add support for context-specific types

### DIFF
--- a/src/DerConverter/Asn/DerAsnContextSpecific.cs
+++ b/src/DerConverter/Asn/DerAsnContextSpecific.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DerConverter.Asn
+{
+    public class DerAsnContextSpecific : DerAsnType
+    {
+        private readonly List<DerAsnType> _items = new List<DerAsnType>();
+
+        internal DerAsnContextSpecific(DerAsnTypeTag tag, Queue<byte> rawData)
+            : base(tag)
+        {
+            if (rawData == null) throw new ArgumentNullException(nameof(rawData));
+            while (rawData.Any()) _items.Add(DerAsnType.Parse(rawData));
+        }
+
+        public DerAsnContextSpecific(DerAsnTypeTag tag, DerAsnType[] items)
+            : base(tag)
+        {
+            if (items == null) throw new ArgumentNullException(nameof(items));
+            _items.AddRange(items);
+        }
+
+        public override object Value => _items.ToArray();
+
+        public IList<DerAsnType> Items => _items;
+
+        protected override byte[] InternalGetBytes()
+        {
+            return _items
+                .Select(x => x.GetBytes())
+                .SelectMany(x => x)
+                .ToArray();
+        }
+    }
+}

--- a/src/DerConverter/Asn/DerAsnType.cs
+++ b/src/DerConverter/Asn/DerAsnType.cs
@@ -40,6 +40,14 @@ namespace DerConverter.Asn
             var typeDataLength = data.DequeueDerLength();
             var typeData = new Queue<byte>(data.Dequeue(typeDataLength));
 
+            // Higher bits indicate the tag is context specific; lower bits indicate the tag value.
+            // E.g. "0xA0" => Context Specific (0),
+            //      "0xA3" => Context Specific (3)
+            if ((typeTag & DerAsnTypeTag.ContextSpecific) == DerAsnTypeTag.ContextSpecific)
+            {
+                return new DerAsnContextSpecific(typeTag, typeData);
+            }
+
             switch (typeTag)
             {
                 case DerAsnTypeTag.Boolean: return new DerAsnBoolean(typeData);

--- a/src/DerConverter/Asn/DerAsnTypeTag.cs
+++ b/src/DerConverter/Asn/DerAsnTypeTag.cs
@@ -13,6 +13,7 @@
         Ia5tring = 0x16,
         UnicodeString = 0x1E,
         Sequence = 0x30,
-        Set = 0x31
+        Set = 0x31,
+        ContextSpecific = 0xA0
     }
 }


### PR DESCRIPTION
ASN.1 allows for context-specific types. The exact details of these types are unknown, but the higher bits are always set to `0xA0`, so you can detect this flag and use a generic `DerAsnContextSpecific` type to catch their value.