### PR TITLE
Mark the assembly as CLS compliant

### DIFF
--- a/src/DerConverter/AssemblyInfo.cs
+++ b/src/DerConverter/AssemblyInfo.cs
@@ -1,6 +1,7 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyVersion("1.0.0.0")]
-
+[assembly: CLSCompliant(true)]
 [assembly: InternalsVisibleTo("DerConverter.Tests")]


### PR DESCRIPTION
All classes are CLS-compliant, so it doesn't hurt marking the assembly as such.