### PR TITLE
Mark the arrays in constructors as params

### DIFF
--- a/src/DerConverter/Asn/DerAsnSequence.cs
+++ b/src/DerConverter/Asn/DerAsnSequence.cs
@@ -24,7 +24,7 @@ namespace DerConverter.Asn
 
         public override object Value => _items.ToArray();
 
-        public IList<DerAsnType> Items => _items;
+        public IReadOnlyList<DerAsnType> Items => _items;
 
         protected override byte[] InternalGetBytes()
         {

--- a/src/DerConverter/Asn/DerAsnSequence.cs
+++ b/src/DerConverter/Asn/DerAsnSequence.cs
@@ -15,7 +15,7 @@ namespace DerConverter.Asn
             while (rawData.Any()) _items.Add(DerAsnType.Parse(rawData));
         }
 
-        public DerAsnSequence(DerAsnType[] items)
+        public DerAsnSequence(params DerAsnType[] items)
             : base(DerAsnTypeTag.Sequence)
         {
             if (items == null) throw new ArgumentNullException(nameof(items));
@@ -24,7 +24,7 @@ namespace DerConverter.Asn
 
         public override object Value => _items.ToArray();
 
-        public IReadOnlyList<DerAsnType> Items => _items;
+        public IList<DerAsnType> Items => _items;
 
         protected override byte[] InternalGetBytes()
         {

--- a/src/DerConverter/Asn/DerAsnSet.cs
+++ b/src/DerConverter/Asn/DerAsnSet.cs
@@ -24,7 +24,7 @@ namespace DerConverter.Asn
 
         public override object Value => _items.ToArray();
 
-        public IList<DerAsnType> Items => _items;
+        public IReadOnlyList<DerAsnType> Items => _items;
 
         protected override byte[] InternalGetBytes()
         {

--- a/src/DerConverter/Asn/DerAsnSet.cs
+++ b/src/DerConverter/Asn/DerAsnSet.cs
@@ -15,7 +15,7 @@ namespace DerConverter.Asn
             while (rawData.Any()) _items.Add(DerAsnType.Parse(rawData));
         }
 
-        public DerAsnSet(DerAsnType[] items)
+        public DerAsnSet(params DerAsnType[] items)
             : base(DerAsnTypeTag.Set)
         {
             if (items == null) throw new ArgumentNullException(nameof(items));
@@ -23,6 +23,8 @@ namespace DerConverter.Asn
         }
 
         public override object Value => _items.ToArray();
+
+        public IList<DerAsnType> Items => _items;
 
         protected override byte[] InternalGetBytes()
         {


### PR DESCRIPTION
- Use the `params` keyword in the constructors that take arrays, so you can do `new DerAsnSequence(new DerAsnNull)` instead of `new DerAsnSequence(new DerAsnType[] { new DerAsnNull })`
- Expose the `Items` as an `IList` instead of a `IReadOnlyList`.  This allows you to modify the collections on the fly.