### PR TITLE
Allow encoding ASN.1 objects using indefinite length encoding

### DIFF
--- a/src/DerConverter/Asn/DerAsnType.cs
+++ b/src/DerConverter/Asn/DerAsnType.cs
@@ -23,7 +23,7 @@ namespace DerConverter.Asn
             var result = new List<byte>();
             result.Add((byte)Tag);
 
-            if (indefiniteLength)
+            if (this.UseIndefiniteLengthEncoding)
             {
                 result.Add(0x80);
             }
@@ -34,7 +34,7 @@ namespace DerConverter.Asn
 
             result.AddRange(rawData);
 
-            if (indefiniteLength)
+            if (this.UseIndefiniteLengthEncoding)
             {
                 result.Add(0x00);
                 result.Add(0x00);

--- a/src/DerConverter/Asn/DerAsnType.cs
+++ b/src/DerConverter/Asn/DerAsnType.cs
@@ -10,6 +10,8 @@ namespace DerConverter.Asn
 
         public abstract object Value { get; }
 
+        public bool UseIndefiniteLengthEncoding { get; set; } = false;
+
         protected DerAsnType(DerAsnTypeTag tag)
         {
             Tag = tag;
@@ -20,8 +22,24 @@ namespace DerConverter.Asn
             var rawData = InternalGetBytes();
             var result = new List<byte>();
             result.Add((byte)Tag);
-            result.AddRange(rawData.Length.ToDerLengthBytes());
+
+            if (indefiniteLength)
+            {
+                result.Add(0x80);
+            }
+            else
+            {
+                result.AddRange(rawData.Length.ToDerLengthBytes());
+            }
+
             result.AddRange(rawData);
+
+            if (indefiniteLength)
+            {
+                result.Add(0x00);
+                result.Add(0x00);
+            }
+
             return result.ToArray();
         }
 

--- a/tests/DerConverter.Tests/Asn/DerAsnSetTests.cs
+++ b/tests/DerConverter.Tests/Asn/DerAsnSetTests.cs
@@ -47,5 +47,29 @@ namespace DerConverter.Tests.Asn
                 0x05, 0x00
             }));
         }
+
+        [Test]
+        public void DerAsnSet_GetBytesIndefiniteLength_ShouldEncodeCorrectly()
+        {
+            var type = new DerAsnSet(new DerAsnType[]
+            {
+                new DerAsnNull(),
+                new DerAsnObjectIdentifier("1.2.840.113549.1.1.1"),
+                new DerAsnNull()
+            });
+
+            type.UseIndefiniteLengthEncoding = true;
+
+            var data = type.GetBytes();
+            Assert.That((DerAsnTypeTag)data[0], Is.EqualTo(DerAsnTypeTag.Set));
+            Assert.That(data[1], Is.EqualTo(0x80)); // 0x80 indicates indefinite length encoding
+            Assert.That(data.Skip(2).ToArray(), Is.EqualTo(new byte[]
+            {
+                0x05, 0x00,
+                0x06, 0x09, 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x01,
+                0x05, 0x00,
+                0x00, 0x00 // Termination marker for indefinite length encoding
+            }));
+        }
     }
 }


### PR DESCRIPTION
I have a use case where I communicate with a remote system (over which I have no control) which crashes when it gets definite-length encoded ASN.1 objects for ASN.1 objects which exceed a certain length.

So this PR adds a `UseIndefiniteLengthEncoding` property to the `DerAsnType` class which allows you to force the encoder to use indefinite length encoding if you want to.