### PR TITLE
Update to NUnit 3.10

### DIFF
--- a/tests/DerConverter.Tests/DerConverter.Tests.csproj
+++ b/tests/DerConverter.Tests/DerConverter.Tests.csproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.7.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.7.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/PemUtils.Tests/PemUtils.Tests.csproj
+++ b/tests/PemUtils.Tests/PemUtils.Tests.csproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.7.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.7.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I was getting OutOfMemoryException with the NUnit test plugin; this seems to be a known problem and upgrading to 3.10 fixed that for me.